### PR TITLE
Add support for image and primitive instantiation

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -295,13 +295,12 @@ fn to_padded_byte_vector<T>(vec: Vec<T>) -> Vec<u8> {
 
 fn to_gltf_material<F: Fn(&Handle<Image>) -> Option<Image>>(
     buffers: &mut BuffersWrapper,
-    mat: &StandardMaterial,
+    mat: Option<&StandardMaterial>,
     image_getter: &F,
-    skip: bool,
 ) -> Result<Option<json::Material>, MeshExportError> {
-    if skip {
+    let Some(mat) = mat else {
         return Ok(None);
-    }
+    };
     let mut material = json::Material {
         pbr_metallic_roughness: json::material::PbrMetallicRoughness {
             base_color_factor: json::material::PbrBaseColorFactor(mat.base_color.as_rgba_f32()),
@@ -464,7 +463,7 @@ fn get_indices_data(
 #[derive(Clone, Debug)]
 pub struct MeshData<'a> {
     pub mesh: &'a Mesh,
-    pub material: &'a StandardMaterial,
+    pub material: Option<&'a StandardMaterial>,
     pub pose: Option<GltfPose>,
 }
 
@@ -498,7 +497,6 @@ pub fn export_meshes<
             &mut buffers,
             data.material,
             &image_getter,
-            options.skip_materials,
         )?;
 
         let mut primitive = json::mesh::Primitive {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,17 +119,17 @@ fn export_test_mesh() -> Result<Vec<u8>, MeshExportError> {
     let (mesh2, material2) = create_bevy_sample_mesh2();
     let data1 = MeshData {
         mesh: &mesh,
-        material: &material,
+        material: Some(&material),
         pose: None,
     };
     let data2 = MeshData {
         mesh: &mesh2,
-        material: &material2,
+        material: Some(&material2),
         pose: None,
     };
     let data3 = MeshData {
         mesh: &mesh,
-        material: &material2,
+        material: Some(&material2),
         pose: Some(GltfPose {
             translation: [2.0, 2.0, 2.0],
             ..Default::default()


### PR DESCRIPTION
This PR uses a hash map to identify duplicated buffers and reuse them across meshes